### PR TITLE
Remove django-ckeditor requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
     packages=find_packages(),
     install_requires=[
         'django >= 1.4.0',
-        'django-ckeditor >= 3.6.2.1',
         'Pillow >= 1.7.7',
     ],
     tests_require=[


### PR DESCRIPTION
NNgroup uses a custom fork of django-ckeditor and there are issues
with heroku installing the requirement a second time based on
django-pagebit's needs.